### PR TITLE
Avoid errors for unknown priority, fixes #4

### DIFF
--- a/src/skjold/tasks.py
+++ b/src/skjold/tasks.py
@@ -79,7 +79,7 @@ def report(configuration: Configuration, results: List[Dict[str, Any]]) -> None:
             "MODERATE": "yellow",
             "HIGH": "red",
             "UNKNOWN": "yellow",
-        }[result["severity"]]
+        }.get(result["severity"])
 
         click.secho("")
         click.secho(result["name"], fg="white", nl=False)


### PR DESCRIPTION
Can reproduce with `echo 'pillow==6.1.0' | skjold audit -s github -`