### PR TITLE
Properly handle PyUp '$meta' when populating advisories from cache.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 fail_fast: true
 default_language_version:
-    python: python3.7
+    python: python3.8
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.5.0


### PR DESCRIPTION
**Changes**

- Handle PyUp `$meta` while populating advisories.
- Set `pre-commit` default python interpreter to `3.8`.