### PR TITLE
Fix Gemnasium provider failing when affected_range string is empty

### DIFF
--- a/src/skjold/sources/gemnasium.py
+++ b/src/skjold/sources/gemnasium.py
@@ -59,9 +59,12 @@ class GemnasiumSecurityAdvisory(SecurityAdvisory):
 
     @property
     def vulnerable_version_range(self) -> List[semver.VersionConstraint]:
-        return [
-            semver.parse_constraint(x) for x in self._json["affected_range"].split("||")
-        ]
+        affected_range = self._json["affected_range"]
+
+        if not affected_range:
+            return [semver.parse_constraint(">=0.0.0")]
+
+        return [semver.parse_constraint(x) for x in affected_range.split("||")]
 
     @property
     def vulnerable_versions(self) -> str:

--- a/tests/fixtures/gemnasium/CVE-2020-28476.yml
+++ b/tests/fixtures/gemnasium/CVE-2020-28476.yml
@@ -1,0 +1,23 @@
+---
+identifier: "CVE-2020-28476"
+package_slug: "pypi/tornado"
+title: "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)"
+description: "All versions of package tornado are vulnerable to Web Cache Poisoning
+  by using a vector called parameter cloaking. When the attacker can separate query
+  parameters using a semicolon (`;`), they can cause a difference in the interpretation
+  of the request between the proxy (running with default configuration) and the server.
+  This can result in malicious requests being cached as completely safe ones, as the
+  proxy would usually not see the semicolon as a separator, and therefore would not
+  include it in a cache key of an unkeyed parameter."
+date: "2021-01-28"
+pubdate: "2021-01-18"
+affected_range: ""
+fixed_versions: []
+affected_versions: "All versions"
+not_impacted: ""
+solution: "Unfortunately, there is no solution available yet."
+urls:
+- "https://nvd.nist.gov/vuln/detail/CVE-2020-28476"
+cvss_v2: "AV:N/AC:M/Au:N/C:P/I:P/A:N"
+cvss_v3: "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:N/I:H/A:H"
+uuid: "477a90cf-fe4b-40e2-849c-0f13e1ff10bd"

--- a/tests/test_gemnasium.py
+++ b/tests/test_gemnasium.py
@@ -59,6 +59,25 @@ def test_ensure_gemnasium_advisory_from_yaml_with_cvss2_only() -> None:
     )
 
 
+def test_ensure_gemnasium_advisory_from_yaml_with_empty_affected_range_string() -> None:
+    obj = GemnasiumSecurityAdvisory.using(gemnasium_advisory_yml("CVE-2020-28476.yml"))
+    assert "cvss_v2" in obj._json
+    obj._json.pop("cvss_v3", None)
+
+    assert obj.package_name == "tornado"
+    assert obj.identifier == "CVE-2020-28476"
+    assert obj.source == "gemnasium"
+    assert obj.severity == "MEDIUM"
+    assert obj.url == "https://nvd.nist.gov/vuln/detail/CVE-2020-28476"
+    assert obj.references == [
+        "https://nvd.nist.gov/vuln/detail/CVE-2020-28476",
+    ]
+    assert obj.vulnerable_versions == ">=0.0.0"
+    assert obj.summary.startswith(
+        "Inconsistent Interpretation of HTTP Requests (HTTP Request Smuggling)"
+    )
+
+
 def test_ensure_gemnasium_advisory_from_yaml_with_no_cvss_vector() -> None:
     obj = GemnasiumSecurityAdvisory.using(gemnasium_advisory_yml("CVE-2014-1932.yml"))
 


### PR DESCRIPTION
Fixes cases where Gemnasium's advisory has an empty `affected_range` field like it is with `CVE-2020-28476`, which causes `vulnerable_version_range()` to crash. These cases translate to versions `>=0.0.0`

You can test this behavior currently using `echo "tornado==1.0.0" | skjold audit - -s gemnasium`

We have to disable gemnasium as a source until this is fixed. Looking forward to having this deployed."

Thanks for skjold, cheers~~