### PR TITLE
Support (temporarily) ignoring findings using `.skjoldignore` files.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,3 +74,8 @@ jobs:
         PYTHONPATH: src
       run: |
         echo "urllib3==1.22" | poetry run skjold -v audit -o json -r -s osv -
+    - name: Run .skjoldignore example
+      env:
+        PYTHONPATH: src
+      run: |
+        echo "urllib3==1.23" | skjold audit -s pypa -i tests/fixtures/formats/ignore/all -

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,4 +38,5 @@ repos:
         language: python
         language_version: python3
         files: ^(poetry\.lock|Pipfile\.lock|requirements.*\.txt)$
+        verbose: true
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,4 +7,5 @@
   language_version: python3
   require_serial: true
   verbose: true
+  always_run: true
   files: ^(poetry\.lock|Pipfile\.lock|requirements.*\.txt)$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,5 @@
   language: python
   language_version: python3
   require_serial: true
+  verbose: true
   files: ^(poetry\.lock|Pipfile\.lock|requirements.*\.txt)$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,5 +7,4 @@
   language_version: python3
   require_serial: true
   verbose: true
-  always_run: true
   files: ^(poetry\.lock|Pipfile\.lock|requirements.*\.txt)$

--- a/.skjoldignore
+++ b/.skjoldignore
@@ -1,0 +1,2 @@
+ignore:
+version: "1.0"

--- a/.skjoldignore
+++ b/.skjoldignore
@@ -1,2 +1,6 @@
 ignore:
+  SKJ-2021-001:
+  - expires: 2022-01-01T12:30:00+0000
+    package: skjold
+    reason: Example .skjoldignore entry.
 version: "1.0"

--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ characters in the first argument of `putrequest()`. NOTE: this is similar to
 CVE-2020-26116.
 https://nvd.nist.gov/vuln/detail/CVE-2020-26137
 --
+
+# Ignore PYSEC-2020-148 finding from PyPA source until a certain date with a specific reason.
+$ skjold ignore urllib3 PYSEC-2020-148 --reason "Very good reason." --expires "2021-01-01T00:00:00+00:00"
+Ignore urllib3 in PYSEC-2020-148 until 2021-01-01 00:00:00+00:00?
+Very good reason.
+--
+Add to '.skjoldignore'? [y/N]: y
+
+# Ignore PYSEC-2020-148 finding from PyPA source for 7 days with "No immediate remediation." reason.
+$ skjold ignore urllib3 PYSEC-2020-148
+Ignore urllib3 in PYSEC-2020-148 until ...?
+No immediate remediation.
+--
+Add to '.skjoldignore'? [y/N]: y
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -167,7 +167,13 @@ repos:
 
 After running `pre-commit install` the hook should be good to go. To configure `skjold` in this scenario I recommend to add the entire configuration to the projects `pyproject.toml` instead of manipulating the hook `args`. See this projects [pyproject.toml](./pyproject.toml) for an example.
 
-**Important!**: If you use `report_only` in any way make sure that you add `verbose: true` to your hook configuration otherwise `pre-commit` won't show you any output since the hook is returning with a zero exit code!
+> **Important!**: If you use `report_only` in any way make sure that you add `verbose: true` to your hook configuration
+otherwise `pre-commit` won't show you any output since the hook is always returning with a zero exit code due
+to `report_only` being set!
+
+> **Important!**: The hook is **only** triggered if a commit changes a dependency file (e.g. `poetry.lock`). Dependencies
+**are not checked on every commit**! You could run `pre-commit run skjold --all-files` as a workaround to mitigate this
+a little. If you have a better solution please let me know!
 
 ## Contributing
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -162,18 +162,20 @@ repos:
     rev: vX.X.X
     hooks:
     - id: skjold
-      verbose: true
+      verbose: true  # Important if used with `report_only`, see below.
 ```
 
-After running `pre-commit install` the hook should be good to go. To configure `skjold` in this scenario I recommend to add the entire configuration to the projects `pyproject.toml` instead of manipulating the hook `args`. See this projects [pyproject.toml](./pyproject.toml) for an example.
+After running `pre-commit install` the hook should be good to go. To configure `skjold` in this scenario I recommend adding the entire configuration to the projects `pyproject.toml` instead of manipulating the hook `args`. See this projects [pyproject.toml](./pyproject.toml) for an example.
+
+> **Important!**: When using `skjold` as a `pre-commit`-hook it only gets triggered if you want to commit changed dependency files (e.g. `Pipenv.lock`, `poetry.lock`, `requirements.txt`,...).
+> It will not continuously check your dependencies on _every_ commit!
+
+You could run `pre-commit run skjold --all-files` manually in your workflow/scripts or run `skjold` manually.
+If you have a better solution please let me know!
 
 > **Important!**: If you use `report_only` in any way make sure that you add `verbose: true` to your hook configuration
 otherwise `pre-commit` won't show you any output since the hook is always returning with a zero exit code due
 to `report_only` being set!
-
-> **Important!**: The hook is **only** triggered if a commit changes a dependency file (e.g. `poetry.lock`). Dependencies
-**are not checked on every commit**! You could run `pre-commit run skjold --all-files` as a workaround to mitigate this
-a little. If you have a better solution please let me know!
 
 ## Contributing
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ repos:
 
 After running `pre-commit install` the hook should be good to go. To configure `skjold` in this scenario I recommend to add the entire configuration to the projects `pyproject.toml` instead of manipulating the hook `args`. See this projects [pyproject.toml](./pyproject.toml) for an example.
 
+**Important!**: If you use `report_only` in any way make sure that you add `require_serial: true` to your hook configuration otherwise `pre-commit` won't show you any output since the hook is returning with a zero exit code!
+
 ## Contributing
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,12 @@ Ignore urllib3 in PYSEC-2020-148 until ...?
 No immediate remediation.
 --
 Add to '.skjoldignore'? [y/N]: y
+
+# Audit `poetry.lock` using a custom `.skjoldignore` file location via `ENV`...
+$ SKJOLD_IGNORE_FILE=<path-to-file> skjold audit -s pyup poetry.lock
+
+# ... or using -i/--ignore-file
+$ skjold audit -s pyup -i <path-to-file> poetry.lock
 ```
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ repos:
     rev: vX.X.X
     hooks:
     - id: skjold
+      verbose: true
 ```
 
 After running `pre-commit install` the hook should be good to go. To configure `skjold` in this scenario I recommend to add the entire configuration to the projects `pyproject.toml` instead of manipulating the hook `args`. See this projects [pyproject.toml](./pyproject.toml) for an example.

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ repos:
 
 After running `pre-commit install` the hook should be good to go. To configure `skjold` in this scenario I recommend to add the entire configuration to the projects `pyproject.toml` instead of manipulating the hook `args`. See this projects [pyproject.toml](./pyproject.toml) for an example.
 
-**Important!**: If you use `report_only` in any way make sure that you add `require_serial: true` to your hook configuration otherwise `pre-commit` won't show you any output since the hook is returning with a zero exit code!
+**Important!**: If you use `report_only` in any way make sure that you add `verbose: true` to your hook configuration otherwise `pre-commit` won't show you any output since the hook is returning with a zero exit code!
 
 ## Contributing
 Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ report_only = true                         # Report only, always exit with zero.
 report_format = 'json'                     # Output findings as `json`. Default is 'cli'.
 cache_dir = '.skjold_cache'                # Cache location (default: `~/.skjold/cache`).
 cache_expires = 86400                      # Cache max. age.
+ignore_file = '.skjoldignore'              # Ignorefile location (default `.skjoldignore`).
 verbose = true                             # Be verbose.
 ```
 
@@ -145,6 +146,7 @@ report_format: json
 verbose: False
 cache_dir: .skjold_cache
 cache_expires: 86400
+ignore_file = '.skjoldignore'
 ```
 
 #### Github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,12 @@ types-toml = "^0.1.2"
 types-PyYAML = "^0.1.8"
 
 [tool.skjold]
-report_only = true
+report_only = false
 report_format = 'cli'
 sources = ["pyup", "github", "gemnasium", "osv", "pypa"]
 cache_dir = ".skjold_cache"
 cache_expires = 43200
+ignore_file = ".skjoldignore"
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/src/skjold/cli.py
+++ b/src/skjold/cli.py
@@ -66,6 +66,7 @@ def cli(
     if config.verbose:
         print_configuration(config)
         click.secho(f"Using {config.cache_dir} as cache location", err=True)
+        click.secho(f"Using {config.ignore_file} as ignore file", err=True)
 
     # Cache Directory
     # Check for cache directory and create it if necessary.
@@ -119,6 +120,15 @@ def config_(config: Configuration) -> None:
     show_default=True,
 )
 @click.option(
+    "ignore_file",
+    "-i",
+    "--ignore-file",
+    type=str,
+    cls=default_from_context("ignore_file", Configuration),
+    help="Ignore file location.",
+    show_default=True,
+)
+@click.option(
     "sources",
     "-s",
     "--sources",
@@ -135,6 +145,7 @@ def audit_(
     report_only: bool,
     report_format: str,
     file_format: str,
+    ignore_file: str,
     sources: List[str],
     file: TextIO,
 ) -> None:
@@ -146,6 +157,8 @@ def audit_(
     """
     config.report_only = report_only
     config.report_format = report_format
+    config.ignore_file = ignore_file
+
     # Only override sources if at least once --source is passed.
     if len(sources) > 0:
         config.sources = list(set(sources))

--- a/src/skjold/cli.py
+++ b/src/skjold/cli.py
@@ -168,26 +168,13 @@ def audit_(
 
     ignore = SkjoldIgnore.using(config.ignore_file)
 
-    results, vulnerable = audit(config, packages, ignore=ignore)
+    findings = audit(config, packages, ignore=ignore)
 
-    report(config, results)
-
-    if len(vulnerable) > 0 and config.verbose:
-        click.secho("", err=True)
-        click.secho(
-            f"  Found {len(vulnerable)} vulnerable packages!",
-            fg="red",
-            blink=True,
-            err=True,
-        )
-        click.secho("", err=True)
-    elif config.verbose:
-        click.secho("", err=True)
-        click.secho(f"  No vulnerable packages found!", fg="green", err=True)
+    vulnerable_packages, _ = report(config, findings)
 
     # By default we want to exit with a non-zero exit-code when we encounter
     # any findings.
-    if not config.report_only and len(vulnerable) > 0:
+    if not config.report_only and len(vulnerable_packages) > 0:
         sys.exit(1)
 
 

--- a/src/skjold/cli.py
+++ b/src/skjold/cli.py
@@ -9,6 +9,7 @@ import click
 import skjold.sources
 
 from skjold.formats import extract_package_list_from, Format
+from skjold.ignore import SkjoldIgnore
 from skjold.tasks import (
     Configuration,
     audit,
@@ -164,7 +165,9 @@ def audit_(
         click.secho(f"{config.sources}", fg="green", nl=False, err=True)
         click.secho(" as source(s).", err=True)
 
-    results, vulnerable = audit(config, packages)
+    ignore = SkjoldIgnore.using(config.ignore_file)
+
+    results, vulnerable = audit(config, packages, ignore=ignore)
 
     report(config, results)
 

--- a/src/skjold/ignore.py
+++ b/src/skjold/ignore.py
@@ -10,6 +10,8 @@ class SkjoldIgnore:
     _path: str
 
     EXPIRES_FMT = "%Y-%m-%dT%H:%M:%S%z"
+    DEFAULT_EXPIRES = datetime.datetime.now() + datetime.timedelta(days=7)
+    DEFAULT_REASON = "No immediate remediation."
 
     def __init__(self, path: str):
         self._path = path
@@ -38,7 +40,7 @@ class SkjoldIgnore:
         self,
         identifier: str,
         package_name: str,
-        reason: str = "No immediate remidiation.",
+        reason: str,
         expires: datetime.datetime = datetime.datetime.now()
         + datetime.timedelta(days=14),
     ) -> bool:

--- a/src/skjold/ignore.py
+++ b/src/skjold/ignore.py
@@ -1,0 +1,76 @@
+import datetime
+import os
+from typing import Dict, Tuple
+
+import yaml
+
+
+class SkjoldIgnore:
+    _doc: Dict
+    _path: str
+
+    EXPIRES_FMT = "%Y-%m-%dT%H:%M:%S%z"
+
+    def __init__(self, path: str):
+        self._path = path
+        self._doc = {"version": "1.0", "ignore": {}}
+
+    @classmethod
+    def using(cls, path: str) -> "SkjoldIgnore":
+        obj = SkjoldIgnore(path)
+        if not os.path.exists(path):
+            return obj
+
+        with open(path) as fh:
+            obj._doc = yaml.safe_load(fh)
+        return obj
+
+    @property
+    def version(self) -> str:
+        return str(self._doc["version"])
+
+    @property
+    def entries(self) -> Dict:
+        entries = self._doc["ignore"]
+        return dict(entries)
+
+    def add(
+        self,
+        identifier: str,
+        package_name: str,
+        reason: str = "No immediate remidiation.",
+        expires: datetime.datetime = datetime.datetime.now()
+        + datetime.timedelta(days=14),
+    ) -> bool:
+
+        expires = expires.replace(tzinfo=datetime.timezone.utc)
+
+        if identifier not in self.entries:
+            self._doc["ignore"][identifier] = []
+
+        self._doc["ignore"][identifier].append(
+            {
+                "package": package_name,
+                "reason": reason,
+                "expires": expires.strftime(SkjoldIgnore.EXPIRES_FMT),
+            }
+        )
+        return True
+
+    def save(self) -> None:
+        with open(self._path, "w") as fh:
+            yaml.safe_dump(self._doc, fh)
+
+    def should_ignore(self, identifier: str, package_name: str) -> Tuple[bool, Dict]:
+        """Returns True a given identifier has an entry in the blacklist."""
+        if identifier not in self.entries:
+            return False, {}
+
+        for entry in self.entries.get(identifier, {}):
+            if entry["package"] == package_name:
+                dt = datetime.datetime.strptime(
+                    f"{entry['expires']}", SkjoldIgnore.EXPIRES_FMT
+                )
+                return datetime.datetime.now(tz=dt.tzinfo) < dt, entry
+
+        return False, {}

--- a/src/skjold/tasks.py
+++ b/src/skjold/tasks.py
@@ -49,7 +49,9 @@ class Configuration:
             "SKJOLD_CACHE_DIR", config.get("cache_dir", self.default_cache_dir)
         )
         self.cache_expires = config.get("cache_expires", self.cache_expires)
-        self.ignore_file = config.get("ignore_file", self.ignore_file)
+        self.ignore_file = os.environ.get(
+            "SKJOLD_IGNORE_FILE", config.get("ignore_file", self.ignore_file)
+        )
         # self.verbose = bool(config.get("verbose", self.verbose))
 
         # Sources

--- a/tests/fixtures/formats/ignore/all
+++ b/tests/fixtures/formats/ignore/all
@@ -1,0 +1,22 @@
+ignore:
+  PYSEC-2019-132:
+  - expires: 2100-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remediation available.
+  PYSEC-2019-133:
+  - expires: 2100-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remediation available.
+  PYSEC-2019-62:
+  - expires: 2100-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remediation available.
+  PYSEC-2019-63:
+  - expires: 2100-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remediation available.
+  PYSEC-2020-148:
+  - expires: 2100-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remediation available.
+version: "1.0"

--- a/tests/fixtures/formats/ignore/example
+++ b/tests/fixtures/formats/ignore/example
@@ -2,21 +2,21 @@ ignore:
   CVE-2018-20060:
   - expires: 2021-01-01T00:00:00+0000
     package: urllib3
-    reason: No remidiation available.
+    reason: No remediation available.
   CVE-2019-11236:
   - expires: 2022-01-01T00:00:00+0000
     package: urllib3
-    reason: No remidiation available.
+    reason: No remediation available.
   CVE-2019-11324:
   - expires: 2022-01-01T00:00:00+0000
     package: urllib3
-    reason: No remidiation available.
+    reason: No remediation available.
   CVE-2020-26137:
   - expires: 2022-01-01T00:00:00+0000
     package: urllib3
-    reason: No remidiation available.
+    reason: No remediation available.
   PYSEC-2020-149:
   - expires: 2022-01-01T00:00:00+0000
     package: urllib3
-    reason: No remidiation available.
+    reason: No remediation available.
 version: "1.0"

--- a/tests/fixtures/formats/ignore/example
+++ b/tests/fixtures/formats/ignore/example
@@ -1,0 +1,22 @@
+ignore:
+  CVE-2018-20060:
+  - expires: 2021-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remidiation available.
+  CVE-2019-11236:
+  - expires: 2022-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remidiation available.
+  CVE-2019-11324:
+  - expires: 2022-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remidiation available.
+  CVE-2020-26137:
+  - expires: 2022-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remidiation available.
+  PYSEC-2020-149:
+  - expires: 2022-01-01T00:00:00+0000
+    package: urllib3
+    reason: No remidiation available.
+version: "1.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,6 +57,59 @@ def test_vulnerable_package_via_cli(
     assert "via github" in result.stdout
 
 
+def test_vulnerable_package_with_ignore_list_via_env(
+    runner: click.testing.CliRunner, cache_dir: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Ensure that using a .skjoldignore file ignores marked findings."""
+    monkeypatch.setenv("SKJOLD_CACHE_DIR", cache_dir)
+    ignore_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "formats", "ignore", "all"
+    )
+    assert os.path.exists(ignore_path)
+    monkeypatch.setenv("SKJOLD_IGNORE_FILE", ignore_path)
+
+    config = Configuration()
+    config.use({"report_only": False, "report_format": "cli", "sources": ["pypa"]})
+    assert config.ignore_file == ignore_path
+
+    # TODO(twu): Figure out how to do this right.
+    input_ = make_input_stream("urllib3==1.23", "utf-8")
+    setattr(input_, "name", "<stdin>")
+
+    result = runner.invoke(cli, args=["audit", "-"], input=input_, obj=config)
+
+    assert "Ignored 5 finding(s)!" in result.stderr
+    assert "No vulnerable packages found!" in result.stderr
+    assert result.exit_code == 0
+
+
+def test_vulnerable_package_with_ignore_list_via_cli(
+    runner: click.testing.CliRunner, cache_dir: str, monkeypatch: MonkeyPatch
+) -> None:
+    """Ensure that using a .skjoldignore file ignores marked findings and can be set via '-i/--ignore-file'."""
+    monkeypatch.setenv("SKJOLD_CACHE_DIR", cache_dir)
+    ignore_path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "formats", "ignore", "all"
+    )
+    assert os.path.exists(ignore_path)
+
+    config = Configuration()
+    config.use({"report_only": False, "report_format": "cli", "sources": ["pypa"]})
+    assert config.ignore_file == ".skjoldignore"
+
+    # TODO(twu): Figure out how to do this right.
+    input_ = make_input_stream("urllib3==1.23", "utf-8")
+    setattr(input_, "name", "<stdin>")
+
+    result = runner.invoke(
+        cli, args=["audit", "-i", ignore_path, "-"], input=input_, obj=config
+    )
+
+    assert "Ignored 5 finding(s)!" in result.stderr
+    assert "No vulnerable packages found!" in result.stderr
+    assert result.exit_code == 0
+
+
 def test_cli_json_report_with_package_list_via_stdin(
     runner: click.testing.CliRunner,
     cache_dir: str,

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -50,7 +50,7 @@ def test_should_ignore_not_expired(
             {
                 "expires": "2021-01-01T00:00:00+0000",
                 "package": "urllib3",
-                "reason": "No remidiation available.",
+                "reason": "No remediation available.",
             },
         ),
     ],
@@ -72,13 +72,14 @@ def test_ignore_add_item(ignorelist: SkjoldIgnore) -> None:
 
     expires = datetime.datetime.utcnow() + datetime.timedelta(days=14)
     expires = expires.replace(tzinfo=datetime.timezone.utc)
+    reason = SkjoldIgnore.DEFAULT_REASON
 
-    assert ignorelist.add("SKJ-0000-00", "example", expires=expires)
+    assert ignorelist.add("SKJ-0000-00", "example", expires=expires, reason=reason)
 
     ignored, entry = ignorelist.should_ignore("SKJ-0000-00", "example")
     assert ignored
     assert entry == {
         "package": "example",
-        "reason": "No immediate remidiation.",
+        "reason": reason,
         "expires": expires.strftime(SkjoldIgnore.EXPIRES_FMT),
     }

--- a/tests/test_ignore.py
+++ b/tests/test_ignore.py
@@ -1,0 +1,84 @@
+import datetime
+import os
+from typing import Dict
+
+import pytest
+
+from skjold.ignore import SkjoldIgnore
+
+
+@pytest.fixture
+def ignorelist() -> SkjoldIgnore:
+    path = os.path.join(
+        os.path.dirname(__file__), "fixtures", "formats", "ignore", "example"
+    )
+    assert os.path.exists(path)
+
+    obj = SkjoldIgnore.using(path)
+    assert obj.version == "1.0"
+    assert len(obj.entries) > 0
+    return obj
+
+
+@pytest.mark.parametrize(
+    "identifier, package",
+    [
+        ("CVE-2019-11236", "urllib3"),
+        ("CVE-2019-11324", "urllib3"),
+        ("CVE-2020-26137", "urllib3"),
+        ("PYSEC-2020-149", "urllib3"),
+    ],
+)
+def test_should_ignore_not_expired(
+    identifier: str, package: str, ignorelist: SkjoldIgnore
+) -> None:
+    """Ensure we only ignore if package and identifier are matching."""
+
+    ignored, _ = ignorelist.should_ignore(identifier, package)
+    assert ignored
+
+    ignored, _ = ignorelist.should_ignore(identifier, "requests")
+    assert not ignored
+
+
+@pytest.mark.parametrize(
+    "identifier, package, entry",
+    [
+        (
+            "CVE-2018-20060",
+            "urllib3",
+            {
+                "expires": "2021-01-01T00:00:00+0000",
+                "package": "urllib3",
+                "reason": "No remidiation available.",
+            },
+        ),
+    ],
+)
+def test_should_ignore_expired(
+    identifier: str, package: str, entry: Dict[str, str], ignorelist: SkjoldIgnore
+) -> None:
+    """Ensure we only ignore if package and identifier are matching."""
+
+    ignored, entry = ignorelist.should_ignore(identifier, package)
+    assert not ignored
+    assert entry == entry
+
+
+def test_ignore_add_item(ignorelist: SkjoldIgnore) -> None:
+    ignored, entry = ignorelist.should_ignore("SKJ-0000-00", "example")
+    assert not ignored
+    assert entry == {}
+
+    expires = datetime.datetime.utcnow() + datetime.timedelta(days=14)
+    expires = expires.replace(tzinfo=datetime.timezone.utc)
+
+    assert ignorelist.add("SKJ-0000-00", "example", expires=expires)
+
+    ignored, entry = ignorelist.should_ignore("SKJ-0000-00", "example")
+    assert ignored
+    assert entry == {
+        "package": "example",
+        "reason": "No immediate remidiation.",
+        "expires": expires.strftime(SkjoldIgnore.EXPIRES_FMT),
+    }


### PR DESCRIPTION
Fixes #42

**Proposed Changes**:
- [x] Add support for `.skjoldignore` file heavily inspired by the `.snyk`[0] ignore syntax. This should add support for permanently or temporarily ignoring findings based on their source identifier.
- [x] Extend `cli` output to show ignored entries.
- [x] Extend `json` output to show ignored entries. 
- [x] Add cli command to append a new finding to the ignore file e.g. `skjold ignore add CVE-2018-20060 ...`.
- [x] Allow setting the ignore file location via `pyproject.toml`.
- [x] Allow setting the ignore file location via `cli` and/or `ENV`.
- [x] Add and update `tests`.

**Example `.skjold_ignore`**:
```
ignore:
  CVE-2018-20060:
  - expires: 2021-01-01T00:00:00+0000
    package: urllib3
    reason: No remidiation available.
  CVE-2019-11236:
  - expires: 2022-01-01T00:00:00+0000
    package: urllib3
    reason: No remidiation available.
  PYSEC-2020-149:
  - expires: 2022-01-01T00:00:00+0000
    package: urllib3
    reason: No remidiation available.
version: "1.0"
```

## Links

- [0]: [snyk.io: The .snyk file](https://support.snyk.io/hc/en-us/articles/360007487097-The-snyk-file)