### PR TITLE
Display helpful message if Github Token is not found/set.

### DIFF
--- a/src/skjold/sources/github.py
+++ b/src/skjold/sources/github.py
@@ -4,6 +4,7 @@ import urllib.request
 from collections import defaultdict
 from typing import List, Tuple, Optional, Iterator, Dict, Any
 
+import click
 import semver
 
 from skjold.models import SecurityAdvisory, SecurityAdvisorySource
@@ -79,7 +80,16 @@ def _query_github_graphql(
 ) -> Tuple[int, str, bool, dict]:
     _after = after and f'"{after}"' or "null"
     _limit = first and int(first) or 1
-    _api_token = os.environ["SKJOLD_GITHUB_API_TOKEN"]
+
+    try:
+        _api_token = os.environ["SKJOLD_GITHUB_API_TOKEN"]
+    except KeyError:
+        raise click.UsageError(
+            "It looks like you're trying to use the github source without providing an access token."
+            "Skjold needs a token to access the Github GraphQL API."
+            "You can generate a token at https://github.com/settings/tokens without giving it any permissions "
+            "and make it available to skjold by setting SKJOLD_GITHUB_TOKEN in your environment."
+        )
 
     query = f"""
     {{
@@ -171,8 +181,9 @@ class Github(SecurityAdvisorySource):
         return os.path.join(self._cache_dir, "github.cache")
 
     def update(self) -> None:
+        data = list(_fetch_github_security_advisories())
         with open(self.path, "w") as fh:
-            json.dump(list(_fetch_github_security_advisories()), fh)
+            json.dump(data, fh)
 
     def has_security_advisory_for(self, package_name: str) -> bool:
         return package_name.strip() in self.advisories.keys()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,5 +1,8 @@
-import pytest
 from typing import Dict, Union, Any
+
+import click
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
 
 from skjold.sources.github import GithubSecurityAdvisory, Github
 
@@ -56,3 +59,12 @@ def test_ensure_accessing_advisories_triggers_update(
     assert len(source.get_security_advisories()) > 100
     assert spy.assert_called
     assert source.total_count > 100
+
+
+def test_ensure_missing_github_token_raises_usage_error(
+    cache_dir: str, monkeypatch: MonkeyPatch
+) -> None:
+    monkeypatch.delenv("SKJOLD_GITHUB_API_TOKEN")
+    with pytest.raises(click.UsageError):
+        gh = Github(cache_dir, 0)
+        gh.update()


### PR DESCRIPTION
Present a more helpful message to the user if `SKJOLD_GITHUB_TOKEN` was not found and the user is trying to use the `github` source. Fixes #54 

> It looks like you're trying to use the github source without providing an access token. Skjold needs a token to access the Github GraphQL API. You can generate a token at https://github.com/settings/tokens without giving it *any* permissions and make it available to skjold by setting `SKJOLD_GITHUB_TOKEN` in your environment.