### PR TITLE
Show correct environment variable name in usage

### DIFF
--- a/src/skjold/sources/github.py
+++ b/src/skjold/sources/github.py
@@ -88,7 +88,7 @@ def _query_github_graphql(
             "It looks like you're trying to use the github source without providing an access token."
             "Skjold needs a token to access the Github GraphQL API."
             "You can generate a token at https://github.com/settings/tokens without giving it any permissions "
-            "and make it available to skjold by setting SKJOLD_GITHUB_TOKEN in your environment."
+            "and make it available to skjold by setting SKJOLD_GITHUB_API_TOKEN in your environment."
         )
 
     query = f"""


### PR DESCRIPTION
When no GitHub token is defined in `SKJOLD_GITHUB_API_TOKEN`, the usage message displays the wrong environment variable name (`SKJOLD_GITHUB_TOKEN`, missing `_API`) to display. This corrects the variable name.

Took me a while to figure out why it won't use my GitHub token :)