### PR TITLE
Add support for handling multiple input files.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,4 +6,4 @@
   language: python
   language_version: python3
   require_serial: true
-  files: ^(poetry\.lock|Pipfile\.lock|requirements.*\.txt)$
+  files: (poetry\.lock|Pipfile\.lock|requirements.*\.txt)$

--- a/README.md
+++ b/README.md
@@ -20,14 +20,13 @@ It currently supports fetching advisories from the following sources:
 
 | Source | Name | Notes |
 | ------:|:----:|:------|
-| [GitHub Advisory Database](https://github.com/advisories) | `github` | |
+| [GitHub Advisory Database](https://github.com/advisories) | `github` | Requires Access Token (See [Github](#github)). |
 | [PyUP.io safety-db](https://github.com/pyupio/safety-db) | `pyup` | |
 | [GitLab gemnasium-db](https://gitlab.com/gitlab-org/security-products/gemnasium-db) | `gemnasium` | |
-| [PYPA Advisory Database](https://github.com/pypa/advisory-db) | `pypa` | **Experimental!** Only supports `ECOSYSTEM` and `SEMVER`! |
-| [OSV.dev Database](https://osv.dev) | `osv` | **Experimental!** Only supports `ECOSYSTEM` and `SEMVER`!<br/> Sends package information to [OSV.dev](https://osv.dev) API. |
+| [PYPA Advisory Database](https://github.com/pypa/advisory-db) | `pypa` | Only supports `ECOSYSTEM`! |
+| [OSV.dev Database](https://osv.dev) | `osv` | Only supports `ECOSYSTEM`!<br/> Sends package information to [OSV.dev](https://osv.dev) API. |
 
-
-No source is enabled by default! Individual sources can be enabled by setting `sources` list (see [Configuration](#configuration)). There is (currently) no de-duplication meaning that using all of them could result in _a lot_ of duplicates.
+No source is enabled by default! Sources can be enabled by setting `sources` list (see [Configuration](#configuration)). There is (currently) no de-duplication meaning that using too many sources at once will result in _a lot_ of duplicates. `skjold` also requires _all_ dependencies to be passed as it *will not* resolve any dependencies at runtime!
 
 ## Motivation
 Skjold was initially created for myself to replace `safety`. ~Which appears to no longer receive monthly updates (see [pyupio/safety-db #2282](https://github.com/pyupio/safety-db/issues/2282))~. I wanted something I can run locally and use for my local or private projects/scripts.
@@ -67,6 +66,9 @@ $ pip list --format=freeze | skjold audit -s github -
 $ skjold -v audit requirements.txt
 $ skjold -v audit poetry.lock
 $ skjold -v audit Pipenv.lock
+
+# Specify specify multiple inputs at once.
+$ skjold -v audit Pipenv.lock poetry.lock requirements.txt
 
 # Using poetry.
 $ poetry export -f requirements.txt | skjold audit -s github -s gemnasium -s pyup -

--- a/src/skjold/cli.py
+++ b/src/skjold/cli.py
@@ -168,7 +168,7 @@ def audit_(
             "Please specify or configure at least one advisory source."
         )
 
-    packages = extract_package_list_from(config, file, file_format)
+    packages = list(extract_package_list_from(config, file, file_format))
 
     if config.verbose:
         click.secho("Checking ", nl=False, err=True)

--- a/src/skjold/cli.py
+++ b/src/skjold/cli.py
@@ -9,7 +9,7 @@ from typing import List, TextIO
 import click
 import skjold.sources
 
-from skjold.formats import extract_package_list_from, Format
+from skjold.formats import extract_dependencies_from_files, Format
 from skjold.ignore import SkjoldIgnore
 from skjold.tasks import (
     Configuration,
@@ -138,7 +138,7 @@ def config_(config: Configuration) -> None:
     show_default=False,
     multiple=True,
 )
-@click.argument("file", type=click.File(), default="./requirements.txt", required=False)
+@click.argument("files", nargs=-1, type=click.File())
 @configuration
 def audit_(
     config: Configuration,
@@ -147,7 +147,7 @@ def audit_(
     file_format: str,
     ignore_file: str,
     sources: List[str],
-    file: TextIO,
+    files: List[TextIO],
 ) -> None:
     """
     Checks a given dependency file against advisory databases.
@@ -168,7 +168,7 @@ def audit_(
             "Please specify or configure at least one advisory source."
         )
 
-    packages = list(extract_package_list_from(config, file, file_format))
+    packages = list(extract_dependencies_from_files(config, files, file_format))
 
     if config.verbose:
         click.secho("Checking ", nl=False, err=True)

--- a/src/skjold/formats.py
+++ b/src/skjold/formats.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import TextIO, MutableMapping, Callable, Optional, Iterator
+from typing import TextIO, MutableMapping, Callable, Optional, Iterator, Sequence
 
 import click
 import toml
@@ -71,16 +71,25 @@ def read_requirements_txt_from(file: TextIO) -> Iterator[Dependency]:
 class Format:  # pragma: no cover
     POETRY: str = "poetry.lock"
     REQUIREMENTS: str = "requirements.txt"
+    REQUIREMENTS_DEV: str = "requirements-dev.txt"
     PIPENV: str = "Pipfile.lock"
 
     SUPPORTED_FORMATS: MutableMapping[str, Callable] = {
         POETRY: read_poetry_lock_from,
         REQUIREMENTS: read_requirements_txt_from,
+        REQUIREMENTS_DEV: read_requirements_txt_from,
         PIPENV: read_pipfile_lock_from,
     }
 
 
-def extract_package_list_from(
+def extract_dependencies_from_files(
+    configuration: Configuration, files: Sequence[TextIO], format_: Optional[str] = None
+) -> Iterator[Dependency]:
+    for file in files:
+        yield from _extract_package_list_from(configuration, file, format_)
+
+
+def _extract_package_list_from(
     configuration: Configuration, file: TextIO, format_: Optional[str] = None
 ) -> Iterator[Dependency]:
     """Extracts the list of tuples containing package name and version."""

--- a/src/skjold/ignore.py
+++ b/src/skjold/ignore.py
@@ -2,6 +2,8 @@ import datetime
 import os
 from typing import Dict, Tuple
 
+from packaging.utils import canonicalize_name
+
 import yaml
 
 
@@ -15,7 +17,7 @@ class SkjoldIgnore:
 
     def __init__(self, path: str):
         self._path = path
-        self._doc = {"version": "1.0", "ignore": {}}
+        self._doc = {"version": "1.1", "ignore": {}}
 
     @classmethod
     def using(cls, path: str) -> "SkjoldIgnore":
@@ -52,7 +54,7 @@ class SkjoldIgnore:
 
         self._doc["ignore"][identifier].append(
             {
-                "package": package_name,
+                "package": canonicalize_name(package_name),
                 "reason": reason,
                 "expires": expires.strftime(SkjoldIgnore.EXPIRES_FMT),
             }
@@ -69,7 +71,7 @@ class SkjoldIgnore:
             return False, {}
 
         for entry in self.entries.get(identifier, {}):
-            if entry["package"] == package_name:
+            if entry["package"] in {package_name, canonicalize_name(package_name)}:
                 dt = datetime.datetime.strptime(
                     f"{entry['expires']}", SkjoldIgnore.EXPIRES_FMT
                 )

--- a/src/skjold/tasks.py
+++ b/src/skjold/tasks.py
@@ -162,6 +162,8 @@ def report(
             click.secho(finding["source"], fg="cyan", nl=False)
             click.secho(" as ", nl=False)
             click.secho(finding["identifier"], fg="yellow", nl=False)
+            click.secho(" found in ", nl=False)
+            click.secho(finding["__file__"]["path"], fg=_color, nl=False)
             click.secho(" ignored until ", nl=False)
             click.secho(finding["ignored"]["expires"], fg="cyan", nl=False)
             click.secho(".")
@@ -180,6 +182,8 @@ def report(
         click.secho(finding["source"], fg="cyan", nl=False)
         click.secho(" as ", nl=False)
         click.secho(finding["identifier"], fg="yellow", nl=False)
+        click.secho(" found in ", nl=False)
+        click.secho(finding["__file__"]["path"], fg=_color, nl=False)
         click.secho("")
 
         click.secho("")

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,12 +1,14 @@
 import io
 import os
-from typing import Optional
+from typing import Optional, List, Tuple, Iterator
 
 import pytest
 
 from skjold.formats import extract_package_list_from, read_requirements_txt_from
-from skjold.models import PackageList
+from skjold.core import Dependency
 from skjold.tasks import Configuration
+
+from packaging.utils import NormalizedName
 
 
 def format_fixture_path_for(folder: str, filename: str) -> str:
@@ -51,51 +53,89 @@ def test_extract_package_versions_from_with_poetry_lock(
 
 
 @pytest.mark.parametrize(
+    "name, version, expected_name, expected_version, expected_canonical_name",
+    [
+        ("PyYAML", "1.0", "PyYAML", "1.0", "pyyaml"),
+        ("Requests", "1.23.0", "Requests", "1.23.0", "requests"),
+        ("requests", "1.22.0", "requests", "1.22.0", "requests"),
+        ("Django", "1.22.0", "Django", "1.22.0", "django"),
+        (
+            "google_cloud_storage",
+            "1.0",
+            "google_cloud_storage",
+            "1.0",
+            "google-cloud-storage",
+        ),
+    ],
+)
+def test_dependency_canonicalize_name(
+    name: str,
+    version: str,
+    expected_name: str,
+    expected_version: str,
+    expected_canonical_name: NormalizedName,
+) -> None:
+    dependency = Dependency(name=name, version=version)
+
+    assert dependency.name == expected_name
+    assert dependency.version == expected_version
+    assert dependency.canonical_name == expected_canonical_name
+
+
+@pytest.mark.parametrize(
     "stdin, expected_package_list",
     [
-        ('package==0.6.0; python_version < "3.8"', [("package", "0.6.0")]),
+        ('package==0.6.0; python_version < "3.8"', [("package", "0.6.0", 1)]),
         (
             'foo==0.6.0; python_version < "3.8"\nbar==1.0.0',
-            [("foo", "0.6.0"), ("bar", "1.0.0")],
+            [("foo", "0.6.0", 1), ("bar", "1.0.0", 2)],
         ),
-        ('foo==1.4.0; python_version < "3.8"', [("foo", "1.4.0")]),
-        ('foo==1.3.0; sys_platform == "win32"', [("foo", "1.3.0")]),
+        ('foo==1.4.0; python_version < "3.8"', [("foo", "1.4.0", 1)]),
+        ('foo==1.3.0; sys_platform == "win32"', [("foo", "1.3.0", 1)]),
         # Ensure that we are able to handle dependencies with (multi-line) hashes.
         (
             "foo==1.3.0 --hash=sha256:05668158c7b85b791c5abde53e50265e16f98ad601c402ba44d70f96c4159612",
-            [("foo", "1.3.0")],
+            [("foo", "1.3.0", 1)],
         ),
         (
             "foo==1.3.0 --hash=sha256:deaddood...\\ \n --hash=sha256:deadbeef...\nbar==1.2.0",
-            [("foo", "1.3.0"), ("bar", "1.2.0")],
+            [("foo", "1.3.0", 1), ("bar", "1.2.0", 3)],
         ),
         # Ensure that we are able to handle comments.
         ("# comment==0.1.2", []),
         (
             'bar==1.2.0\n # comment==0.1.2\nfoo==1.3.0; sys_platform == "win32"',
-            [("bar", "1.2.0"), ("foo", "1.3.0")],
+            [("bar", "1.2.0", 1), ("foo", "1.3.0", 3)],
         ),
         # Ensure we skip invalid lines.
         (
             "bar==1.2.0\n--trusted-host internal-host\nfoo==1.3.0\n--extra-index-url http://internal-host/pypi/index/",
-            [("bar", "1.2.0"), ("foo", "1.3.0")],
+            [("bar", "1.2.0", 1), ("foo", "1.3.0", 3)],
         ),
     ],
 )
 def test_extract_package_versions_from(
-    stdin: str, expected_package_list: PackageList
+    stdin: str, expected_package_list: List[Tuple[str, str, int]]
 ) -> None:
-    packages = read_requirements_txt_from(io.StringIO(stdin))
-    assert list(packages) == expected_package_list
+    contents = io.StringIO(stdin)
+    contents.name = "<stdin>"
+    packages = read_requirements_txt_from(contents)
+
+    def _get_dependencies(items: List[Tuple[str, str, int]]) -> Iterator[Dependency]:
+        for name, version, line_no in items:
+            yield Dependency(name=name, version=version, source=("<stdin>", line_no))
+
+    assert list(packages) == list(_get_dependencies(expected_package_list))
 
 
 def test_extract_package_versions_from_file_with_hashes() -> None:
-    with open(format_fixture_path_for("pip", "requirements_with_hashes.txt")) as fh:
+    path_ = format_fixture_path_for("pip", "requirements_with_hashes.txt")
+    with open(path_) as fh:
         packages = read_requirements_txt_from(fh)
         assert list(packages) == [
-            ("appdirs", "1.4.3"),
-            ("argh", "0.26.2"),
-            ("aspy.yaml", "1.3.0"),
-            ("atomicwrites", "1.3.0"),
-            ("attrs", "19.3.0"),
+            Dependency("appdirs", "1.4.3", (path_, 1)),
+            Dependency("argh", "0.26.2", (path_, 4)),
+            Dependency("aspy.yaml", "1.3.0", (path_, 7)),
+            Dependency("atomicwrites", "1.3.0", (path_, 10)),
+            Dependency("attrs", "19.3.0", (path_, 13)),
         ]

--- a/tests/test_osv.py
+++ b/tests/test_osv.py
@@ -3,6 +3,9 @@ from typing import Any
 
 import pytest
 import yaml
+from skjold.core import Dependency
+
+from packaging.utils import NormalizedName
 
 from skjold.sources.osv import OSV, OSVSecurityAdvisory, _osv_dev_api_request
 
@@ -111,7 +114,7 @@ def test_ensure_is_affected(
 
 
 def test_osv_advisory_with_vulnerable_package_via_osv_api() -> None:
-    vulnerabilities = _osv_dev_api_request("jinja2", "2.11.2")
+    vulnerabilities = _osv_dev_api_request(NormalizedName("jinja2"), "2.11.2")
     assert vulnerabilities[0]
 
     obj = OSVSecurityAdvisory.using(vulnerabilities[0])[0]
@@ -135,16 +138,16 @@ def test_ensure_pypi_advisory_db_update(cache_dir: str) -> None:
     assert source.total_count == 0
     assert len(source._advisories) == 0
 
-    assert source.has_security_advisory_for("ansible")
+    assert source.has_security_advisory_for(Dependency("ansible", "0.0.0"))
 
-    found, findings = source.is_vulnerable_package("doesnotexist", "1.0.0")
+    found, findings = source.is_vulnerable_package(Dependency("doesnotexist", "1.0.0"))
     assert found is False and len(findings) == 0
 
-    found, findings = source.is_vulnerable_package("ansible", "2.8.1")
+    found, findings = source.is_vulnerable_package(Dependency("ansible", "2.8.1"))
     assert found and len(findings) > 0
 
-    found, findings = source.is_vulnerable_package("ansible", "2.8.3")
+    found, findings = source.is_vulnerable_package(Dependency("ansible", "2.8.3"))
     assert found and len(findings) > 0
 
-    found, findings = source.is_vulnerable_package("httpx", "0.19.0")
+    found, findings = source.is_vulnerable_package(Dependency("httpx", "0.19.0"))
     assert found is True and len(findings) > 0

--- a/tests/test_pypa.py
+++ b/tests/test_pypa.py
@@ -1,3 +1,4 @@
+from skjold.core import Dependency
 from skjold.sources.pypa import PyPAAdvisoryDB
 
 
@@ -10,16 +11,16 @@ def test_ensure_pypi_advisory_db_update(cache_dir: str) -> None:
     assert len(source._advisories) > 0
     assert source.total_count > 100
 
-    assert source.has_security_advisory_for("ansible")
+    assert source.has_security_advisory_for(Dependency("ansible", "0.0.0"))
 
-    found, findings = source.is_vulnerable_package("doesnotexist", "1.0.0")
+    found, findings = source.is_vulnerable_package(Dependency("doesnotexist", "1.0.0"))
     assert found is False and len(findings) == 0
 
-    found, findings = source.is_vulnerable_package("ansible", "2.8.1")
+    found, findings = source.is_vulnerable_package(Dependency("ansible", "2.8.1"))
     assert found and len(findings) > 0
 
-    found, findings = source.is_vulnerable_package("ansible", "2.8.3")
+    found, findings = source.is_vulnerable_package(Dependency("ansible", "2.8.3"))
     assert found and len(findings) > 0
 
-    found, findings = source.is_vulnerable_package("httpx", "0.19.0")
+    found, findings = source.is_vulnerable_package(Dependency("httpx", "0.19.0"))
     assert found and len(findings) >= 0

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -3,8 +3,14 @@ from typing import List, Any, Tuple
 
 import pytest
 
-from skjold.models import SecurityAdvisorySource, SecurityAdvisory, SkjoldException
+from skjold.core import (
+    Dependency,
+    SecurityAdvisorySource,
+    SecurityAdvisory,
+    SkjoldException,
+)
 from skjold.tasks import register_source, is_registered_source, Configuration
+from packaging.utils import NormalizedName
 
 
 class DummyAdvisory(SecurityAdvisory):
@@ -18,7 +24,11 @@ class DummyAdvisory(SecurityAdvisory):
 
     @property
     def package_name(self) -> str:
-        return "dummy"
+        return "DuMmY"
+
+    @property
+    def canonical_name(self) -> NormalizedName:
+        return NormalizedName(self.package_name)
 
     @property
     def url(self) -> str:
@@ -59,15 +69,15 @@ class DummyAdvisorySource(SecurityAdvisorySource):
         pass
 
     def update(self) -> None:
-        self._advisories = {"single": [DummyAdvisory()]}
+        self._advisories = {NormalizedName("single"): [DummyAdvisory()]}
 
-    def has_security_advisory_for(self, package_name: str) -> bool:
-        if package_name in ["vulnerable"]:
+    def has_security_advisory_for(self, dependency: Dependency) -> bool:
+        if dependency.canonical_name in ["vulnerable"]:
             return True
         return False
 
     def is_vulnerable_package(
-        self, package_name: str, package_version: str
+        self, dependency: Dependency
     ) -> Tuple[bool, List[SecurityAdvisory]]:
         return False, []
 


### PR DESCRIPTION
This (hopefully) makes running `skjold` in monorepos and/or auditing multiple files at once work (easier).

`pre-commit run --all-files` should now be able to successfully pass any `poetry.lock`, `requirements.txt`, `requirements-dev.txt`, and/or `Pipfile.lock` file(s) to `skjold`.

**Proposed Changes**
- Add `dataclass` to better handle and keep track where dependencies originated from.
- Use canonical names when building indices or reading from files.
- Support passing and auditing multiple files at once. 
- Resolves #114, 
- Resolves #113.